### PR TITLE
Handle documentation changes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -11,7 +11,7 @@ on.generating = false
 sha1.prefix = false
 
 [other]
-sigfiles.version = 1.5
+sigfiles.version = 1.6
 phpdoc.url = https://php.net/manual/en/
 license = ''
 

--- a/src/PhpClass.php
+++ b/src/PhpClass.php
@@ -78,7 +78,7 @@ class PhpClass extends PhpType {
 
     protected function initInternal(): void {
         parent::initInternal();
-        $this->implements = Html::queryValues($this->xpath(), './/span[@class="oointerface"]/a', $this->typeInfo, true);
+        $this->implements = Html::queryValues($this->xpath(), './/div[@class="classsynopsisinfo"]//a[@class="interfacename"]', $this->typeInfo, true);
     }
 
 }

--- a/src/PhpDoc.php
+++ b/src/PhpDoc.php
@@ -97,7 +97,9 @@ final class PhpDoc {
             $rows = Html::queryNodes($this->xpath, '//table[@class="doctable table"]/tbody/tr', null, true);
             foreach ($rows as $row) {
                 $columns = Html::queryNodes($this->xpath, './td[not(@class="empty")]', $row, false);
-                $name = Php::sanitizeConstantName(trim($columns->item(0)->nodeValue), $sanitizeClassConstants);
+                // constant name index of errorfunc.constants.html is 1
+                $nameIndex = SourceDocFixer::getConstantNameIndex($element);
+                $name = Php::sanitizeConstantName(trim($columns->item($nameIndex)->nodeValue), $sanitizeClassConstants);
                 if (array_key_exists($name, $this->constants)) {
                     Log::error("The constant key '$name' already exists");
                 }

--- a/src/PhpType.php
+++ b/src/PhpType.php
@@ -49,7 +49,20 @@ abstract class PhpType extends SigFileElement {
             ->parseType($this->name->asHtmlIdent());
         $this->typeInfo= Html::querySingleNode($this->xpath(), '//div[@class="classsynopsis"]');
         $this->modifiers = array_unique(Html::queryValues($this->xpath(), './/div[@class="classsynopsisinfo"]//strong[@class="classname"]//preceding::span[@class="modifier"]', $this->typeInfo, true));
-        $this->extends = Html::queryValues($this->xpath(), './/span[@class="ooclass"]//a', $this->typeInfo, true);
+        if (empty($this->modifiers)) {
+            // e.g. class.backedenum.html
+            $modifier = Html::queryFirstValue($this->xpath(), './/div[@class="classsynopsisinfo"]//span[@class="modifier"]', $this->typeInfo, true);
+            if ($modifier != null) {
+                $this->modifiers[] = $modifier;
+            }
+        }
+        // there may be not `class="ooclass"`
+        if (Php::isInterface($this->modifiers)) {
+            $this->extends = Html::queryValues($this->xpath(), './/a[@class="interfacename"]', $this->typeInfo, true);
+        } else {
+            // e.g. class.argumentcounterror.html
+            $this->extends = Html::queryValues($this->xpath(), './/a[@class="classname"]', $this->typeInfo, true);
+        }
         $this->initFields();
         $this->initMethods();
     }

--- a/src/PhpTypes.php
+++ b/src/PhpTypes.php
@@ -74,14 +74,14 @@ class PhpTypes extends PhpElements {
     private function initName(): PhpName {
         $name = Html::queryFirstValue($this->xpath(), '//*[@class="classsynopsisinfo"]//strong[@class="classname"]', null, true);
         if ($name === null) {
+            // e.g. class.throwable.html
+            $name = Html::queryFirstValue($this->xpath(), '//*[@class="classsynopsisinfo"]//strong[@class="interfacename"]', null, true);
+        }
+        if ($name === null) {
             $titleParts = explode(' ', $this->getTitle());
             if (count($titleParts) === 3) {
                 $name = $titleParts[1];
             }
-        }
-        if ($name === null) {
-            // e.g. class.throwable.html
-            $name = Html::queryFirstValue($this->xpath(), '//*[@class="classsynopsisinfo"]//strong[@class="interfacename"]', null, true);
         }
         if ($name === null) {
             Log::error("Missing name in file '$this->file'", true);

--- a/src/utils/Php.php
+++ b/src/utils/Php.php
@@ -243,6 +243,10 @@ final class Php {
         return $result;
     }
 
+    public static function isInterface(array $modifiers): bool {
+        return in_array('interface', $modifiers, true);
+    }
+
     private static function isBuiltinType(string $type) {
         $type = strtolower($type);
         if (in_array($type, self::$builtInTypes)) {

--- a/src/utils/SourceDocFixer.php
+++ b/src/utils/SourceDocFixer.php
@@ -104,4 +104,16 @@ class SourceDocFixer {
         return false;
     }
 
+    public static function getConstantNameIndex(string $name): int {
+        $result = 0;
+        switch ($name) {
+            case 'errorfunc':
+                // see: https://www.php.net/manual/en/errorfunc.constants.php
+                $result = 1;
+                break;
+            default:
+                break;
+        }
+        return $result;
+    }
 }


### PR DESCRIPTION
### Fix constants of errorfunc 

- https://www.php.net/manual/en/errorfunc.constants.php
- Constant name index is `1`
<details>
<summary>Diff</summary>

```diff
diff --git a/output/errorfunc.php b/output/errorfunc.php
index 7400b1b..80c17d1 100644
--- a/output/errorfunc.php
+++ b/output/errorfunc.php
@@ -135,83 +135,83 @@ namespace {
 	function user_error(string $message, int $error_level = E_USER_NOTICE): bool {}

 	/**
-	 * Fatal run-time errors. These indicate errors that can not be recovered from, such as a memory allocation problem. Execution of the script is halted.
+	 * All errors, warnings, and notices.
 	 */
-	define('1', null);
+	define('E_ALL', 32767);

 	/**
-	 * User-generated notice message. This is like an <b><code>E_NOTICE</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
+	 * Fatal compile-time errors. This is like an <b><code>E_ERROR</code></b>, except it is generated by the Zend Scripting Engine.
 	 */
-	define('1024', null);
+	define('E_COMPILE_ERROR', 64);

 	/**
 	 * Compile-time warnings (non-fatal errors). This is like an <b><code>E_WARNING</code></b>, except it is generated by the Zend Scripting Engine.
 	 */
-	define('128', null);
+	define('E_COMPILE_WARNING', 128);

 	/**
 	 * Fatal errors that occur during PHP's initial startup. This is like an <b><code>E_ERROR</code></b>, except it is generated by the core of PHP.
 	 */
-	define('16', null);
+	define('E_CORE_ERROR', 16);

 	/**
-	 * User-generated warning message. This is like an <b><code>E_DEPRECATED</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
+	 * Warnings (non-fatal errors) that occur during PHP's initial startup. This is like an <b><code>E_WARNING</code></b>, except it is generated by the core of PHP.
 	 */
-	define('16384', null);
+	define('E_CORE_WARNING', 32);

 	/**
-	 * Run-time warnings (non-fatal errors). Execution of the script is not halted.
+	 * Run-time notices. Enable this to receive warnings about code that will not work in future versions.
 	 */
-	define('2', null);
+	define('E_DEPRECATED', 8192);

 	/**
-	 * Enable to have PHP suggest changes to your code which will ensure the best interoperability and forward compatibility of your code.
+	 * Fatal run-time errors. These indicate errors that can not be recovered from, such as a memory allocation problem. Execution of the script is halted.
 	 */
-	define('2048', null);
+	define('E_ERROR', 1);

 	/**
-	 * User-generated error message. This is like an <b><code>E_ERROR</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
+	 * Run-time notices. Indicate that the script encountered something that could indicate an error, but could also happen in the normal course of running a script.
 	 */
-	define('256', null);
+	define('E_NOTICE', 8);

 	/**
-	 * Warnings (non-fatal errors) that occur during PHP's initial startup. This is like an <b><code>E_WARNING</code></b>, except it is generated by the core of PHP.
+	 * Compile-time parse errors. Parse errors should only be generated by the parser.
 	 */
-	define('32', null);
+	define('E_PARSE', 4);

 	/**
-	 * All errors, warnings, and notices.
+	 * Catchable fatal error. It indicates that a probably dangerous error occurred, but did not leave the Engine in an unstable state. If the error is not caught by a user defined handle (see also <code>set_error_handler()</code>), the application aborts as it was an <b><code>E_ERROR</code></b>.
 	 */
-	define('32767', null);
+	define('E_RECOVERABLE_ERROR', 4096);

 	/**
-	 * Compile-time parse errors. Parse errors should only be generated by the parser.
+	 * Enable to have PHP suggest changes to your code which will ensure the best interoperability and forward compatibility of your code.
 	 */
-	define('4', null);
+	define('E_STRICT', 2048);

 	/**
-	 * Catchable fatal error. It indicates that a probably dangerous error occurred, but did not leave the Engine in an unstable state. If the error is not caught by a user defined handle (see also <code>set_error_handler()</code>), the application aborts as it was an <b><code>E_ERROR</code></b>.
+	 * User-generated warning message. This is like an <b><code>E_DEPRECATED</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
 	 */
-	define('4096', null);
+	define('E_USER_DEPRECATED', 16384);

 	/**
-	 * User-generated warning message. This is like an <b><code>E_WARNING</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
+	 * User-generated error message. This is like an <b><code>E_ERROR</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
 	 */
-	define('512', null);
+	define('E_USER_ERROR', 256);

 	/**
-	 * Fatal compile-time errors. This is like an <b><code>E_ERROR</code></b>, except it is generated by the Zend Scripting Engine.
+	 * User-generated notice message. This is like an <b><code>E_NOTICE</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
 	 */
-	define('64', null);
+	define('E_USER_NOTICE', 1024);

 	/**
-	 * Run-time notices. Indicate that the script encountered something that could indicate an error, but could also happen in the normal course of running a script.
+	 * User-generated warning message. This is like an <b><code>E_WARNING</code></b>, except it is generated in PHP code by using the PHP function <code>trigger_error()</code>.
 	 */
-	define('8', null);
+	define('E_USER_WARNING', 512);

 	/**
-	 * Run-time notices. Enable this to receive warnings about code that will not work in future versions.
+	 * Run-time warnings (non-fatal errors). Execution of the script is not halted.
 	 */
-	define('8192', null);
+	define('E_WARNING', 2);

 }
diff --git a/output/reserved.php b/output/reserved.php
index cb2a092..5e49a60 100644
--- a/output/reserved.php
+++ b/output/reserved.php
@@ -4,86 +4,6 @@ namespace {

 	define('DEFAULT_INCLUDE_PATH', '.:/usr/share/php');

-	/**
-	 * Error reporting constant
-	 */
-	define('E_ALL', 32767);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_COMPILE_ERROR', 64);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_COMPILE_WARNING', 128);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_CORE_ERROR', 16);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_CORE_WARNING', 32);
-
-	/**
-	 * Error reporting constant.
-	 */
-	define('E_DEPRECATED', 8192);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_ERROR', 1);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_NOTICE', 8);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_PARSE', 4);
-
-	/**
-	 * Error reporting constant.
-	 */
-	define('E_RECOVERABLE_ERROR', 4096);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_STRICT', 2048);
-
-	/**
-	 * Error reporting constant.
-	 */
-	define('E_USER_DEPRECATED', 16384);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_USER_ERROR', 256);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_USER_NOTICE', 1024);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_USER_WARNING', 512);
-
-	/**
-	 * Error reporting constant
-	 */
-	define('E_WARNING', 2);
-
 	/**
 	 * See Booleans.
 	 */
```
</details>

### Fix the extends part 

- There may be no longer `class="ooclass"`
- So, check `class="interfacename"` or `class="classname"`

e.g.
```diff
--- a/resources/php-chunked-xhtml/class.backedenum.html
+++ b/resources/php-chunked-xhtml/class.backedenum.html
@@ -45,17 +45,12 @@
    <h2 class="title">Interface synopsis</h2>

-   <div class="classsynopsis">
-    <div class="ooclass">
+   <div class="classsynopsis"><div class="classsynopsisinfo">

-    </div>
+     <span class="modifier">interface</span> <strong class="interfacename"><strong class="interfacename">BackedEnum</strong></strong>

-    <div class="classsynopsisinfo">
-     <span class="oointerface"><span class="modifier">interface</span> <strong class="interfacename">BackedEnum</strong></span><span class="ooclass">
       <span class="modifier">extends</span>
-       <a href="class.unitenum.html" class="classname">UnitEnum</a>
-     </span>
-     {</div>
\ No newline at end of file
+      <a href="class.unitenum.html" class="interfacename">UnitEnum</a> {</div>
\ No newline at end of file

     <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
     <div class="methodsynopsis dc-description">
```

```diff
--- a/resources/php-chunked-xhtml/class.argumentcounterror.html
+++ b/resources/php-chunked-xhtml/class.argumentcounterror.html
@@ -33,9 +33,13 @@
   <div class="section" id="argumentcounterror.intro">
    <h2 class="title">Introduction</h2>
    <p class="para">
-    <span class="ooclass"><strong class="classname">ArgumentCountError</strong></span> is thrown
+    <span class="ooclass"><span class="classname"><strong class="classname">ArgumentCountError</strong></span></span> is thrown
     when too few arguments are passed to a user-defined function or method.
    </p>
+   <p class="para">
+    This error is also thrown when too many arguments are passed to a
+    non-variadic built-in function.
+   </p>
   </div>

@@ -43,20 +47,14 @@
    <h2 class="title">Class synopsis</h2>

-   <div class="classsynopsis">
-    <div class="ooclass">
+   <div class="classsynopsis"><div class="classsynopsisinfo">

-    </div>
+     <span class="modifier">class</span> <strong class="classname"><strong class="exceptionname">ArgumentCountError</strong></strong>

-    <div class="classsynopsisinfo">
-     <span class="ooclass">
-      <span class="modifier">class</span> <strong class="classname">ArgumentCountError</strong>
-     </span>

-     <span class="ooclass">
+
       <span class="modifier">extends</span>
        <a href="class.typeerror.html" class="classname">TypeError</a>
-     </span>
\ No newline at end of file
      {</div>

     <div class="classsynopsisinfo classsynopsisinfo_comment">/* Inherited properties */</div>
```

### Fix the implements part 

- There may be no longer class="oointerface"

```diff
--- a/resources/php-chunked-xhtml/class.dateperiod.html
+++ b/resources/php-chunked-xhtml/class.dateperiod.html
@@ -47,19 +47,15 @@
    <h2 class="title">Class synopsis</h2>

-   <div class="classsynopsis">
-    <div class="ooclass">
+   <div class="classsynopsis"><div class="classsynopsisinfo">

-    </div>
+     <span class="modifier">class</span> <strong class="classname"><strong class="classname">DatePeriod</strong></strong>

-    <div class="classsynopsisinfo">
-     <span class="ooclass">
-      <span class="modifier">class</span> <strong class="classname">DatePeriod</strong>
-     </span>

-     <span class="oointerface"><span class="modifier">implements</span>
-       <a href="class.iteratoraggregate.html" class="interfacename">IteratorAggregate</a></span> {</div>

+     <span class="modifier">implements</span>
+      <a href="class.iteratoraggregate.html" class="interfacename">IteratorAggregate</a> {</div>
+
     <div class="classsynopsisinfo classsynopsisinfo_comment">/* Constants */</div>
     <div class="fieldsynopsis">
      <span class="modifier">public</span>
```

### Check an interface name before check a title 

- Fix the below change

```diff
--- a/resources/php-chunked-xhtml/class.ds-collection.html
+++ b/resources/php-chunked-xhtml/class.ds-collection.html
@@ -28,7 +28,7 @@
  <h1 class="title">The Collection interface</h1>

- <div class="partintro"><p class="verinfo">(No version information available, might only be in Git)</p>
+ <div class="partintro"><p class="verinfo">(PECL ds &gt;= 1.0.0)</p>

   <div class="section" id="ds-collection.intro">
@@ -45,24 +45,30 @@
    <h2 class="title">Interface synopsis</h2>

-   <div class="classsynopsis">
-    <div class="ooclass"></div>
+   <div class="classsynopsis"><div class="classsynopsisinfo">
+    <span class="modifier">interface</span> <strong class="interfacename"><strong class="interfacename">Ds\Collection</strong></strong>

+    <span class="modifier">extends</span>
+      <a href="class.countable.html" class="interfacename">Countable</a>,
+     <a href="class.iteratoraggregate.html" class="interfacename">IteratorAggregate</a>,
+     <a href="class.jsonserializable.html" class="interfacename">JsonSerializable</a> {</div>

-    <div class="classsynopsisinfo">
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
+    <div class="methodsynopsis dc-description">
+   <span class="modifier">public</span> <span class="methodname"><a href="ds-collection.clear.html" class="methodname">clear</a></span>(): <span class="type"><span class="type void">void</span></span></div>
+<div class="methodsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><a href="ds-collection.copy.html" class="methodname">copy</a></span>(): <span class="type"><a href="class.ds-collection.html" class="type Ds\Collection">Ds\Collection</a></span></div>
+<div class="methodsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><a href="ds-collection.isempty.html" class="methodname">isEmpty</a></span>(): <span class="type">bool</span></div>
+<div class="methodsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><a href="ds-collection.toarray.html" class="methodname">toArray</a></span>(): <span class="type">array</span></div>

-    <span class="ooclass"><span class="modifier">class</span> <strong class="classname">Ds\Collection</strong></span>

-    <span class="oointerface"><span class="modifier">implements</span>  <a href="class.countable.html" class="interfacename">Countable</a></span><span class="oointerface">,  <a href="class.iteratoraggregate.html" class="interfacename">IteratorAggregate</a></span><span class="oointerface">,  <a href="class.jsonserializable.html" class="interfacename">JsonSerializable</a></span> {</div>
+    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Inherited methods */</div>
+    <div class="methodsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><a href="countable.count.html" class="methodname">Countable::count</a></span>(): <span class="type">int</span></div>

+    <div class="methodsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><a href="iteratoraggregate.getiterator.html" class="methodname">IteratorAggregate::getIterator</a></span>(): <span class="type"><a href="class.traversable.html" class="type Traversable">Traversable</a></span></div>

-    <div class="classsynopsisinfo classsynopsisinfo_comment">/* Methods */</div>
-    <div class="methodsynopsis dc-description">
-   <span class="modifier">abstract</span> <span class="modifier">public</span> <span class="methodname"><a href="ds-collection.clear.html" class="methodname">clear</a></span>(): <span class="type"><span class="type void">void</span></span></div>
-<div class="methodsynopsis dc-description"><span class="modifier">abstract</span> <span class="modifier">public</span> <span class="methodname"><a href="ds-collection.copy.html" class="methodname">copy</a></span>(): <span class="type"><a href="class.ds-collection.html" class="type Ds\Collection">Ds\Collection</a></span></div>
-<div class="methodsynopsis dc-description"><span class="modifier">abstract</span> <span class="modifier">public</span> <span class="methodname"><a href="ds-collection.isempty.html" class="methodname">isEmpty</a></span>(): <span class="type">bool</span></div>
-<div class="methodsynopsis dc-description"><span class="modifier">abstract</span> <span class="modifier">public</span> <span class="methodname"><a href="ds-collection.toarray.html" class="methodname">toArray</a></span>(): <span class="type">array</span></div>
+    <div class="methodsynopsis dc-description"><span class="modifier">public</span> <span class="methodname"><a href="jsonserializable.jsonserialize.html" class="methodname">JsonSerializable::jsonSerialize</a></span>(): <span class="type"><a href="language.types.declarations.html#language.types.declarations.mixed" class="type mixed">mixed</a></span></div>

+
\ No newline at end of file
    }</div>
```