### PR TITLE
Add constants of function.debug-backtrace.html

### DIFF
--- a/src/PhpConstants.php
+++ b/src/PhpConstants.php
@@ -13,6 +13,7 @@ class PhpConstants extends PhpElements {
 
     public static function collect(): void {
         $constants = glob(Config::get()->inputDir() . '/*.constants.*html', GLOB_ERR);
+        $constants[] = Config::get()->inputDir() . '/function.debug-backtrace.html';
         foreach ($constants as $consts) {
             $refName = self::getConstantsName($consts);
             if (Config::get()->isBlacklistConstants($refName)) {
@@ -37,7 +38,8 @@ class PhpConstants extends PhpElements {
     }
 
     public static function getConstantsName(string $constants): string {
-        $name = strtolower(str_replace(['.html', 'constants.', 'constants'], '', basename($constants)));
+        // function.: function.debug-backtrace.html
+        $name = strtolower(str_replace(['.html', 'constants.', 'constants', 'function.'], '', basename($constants)));
         while (Strings::endsWith($name, '.')) {
             $name = substr($name, 0, -1);
         }

--- a/src/PhpDoc.php
+++ b/src/PhpDoc.php
@@ -94,7 +94,8 @@ final class PhpDoc {
 
     public function parseConstants(string $element, bool $sanitizeClassConstants, bool $includingDocTable = false): PhpDoc {
         if ($includingDocTable) {
-            $rows = Html::queryNodes($this->xpath, '//table[@class="doctable table"]/tbody/tr', null, true);
+            $expression = SourceDocFixer::getConstantTableRowsExpression($element);
+            $rows = Html::queryNodes($this->xpath, $expression, null, true);
             foreach ($rows as $row) {
                 $columns = Html::queryNodes($this->xpath, './td[not(@class="empty")]', $row, false);
                 // constant name index of errorfunc.constants.html is 1

--- a/src/utils/SourceDocFixer.php
+++ b/src/utils/SourceDocFixer.php
@@ -116,4 +116,16 @@ class SourceDocFixer {
         }
         return $result;
     }
+
+    public static function getConstantTableRowsExpression(string $name): string {
+        $result = '//table[@class="doctable table"]/tbody/tr';
+        switch ($name) {
+            case 'debug-backtrace': // function.debug-backtrace.html
+                $result = '//dl/dd/table[@class="doctable table"]/tbody/tr';
+                break;
+            default:
+                break;
+        }
+        return $result;
+    }
 }


### PR DESCRIPTION
- https://www.php.net/manual/en/function.debug-backtrace.php
```diff
diff --git a/output/errorfunc.php b/output/errorfunc.php
index 149e9802..0a4e031b 100644
--- a/output/errorfunc.php
+++ b/output/errorfunc.php
@@ -134,6 +134,16 @@ namespace {
         */
        function user_error(string $message, int $error_level = E_USER_NOTICE): bool {}

+       /**
+        * Whether or not to omit the "args" index, and thus all the function/method arguments, to save memory.
+        */
+       define('DEBUG_BACKTRACE_IGNORE_ARGS', 2);
+
+       /**
+        * Whether or not to populate the "object" index.
+        */
+       define('DEBUG_BACKTRACE_PROVIDE_OBJECT', 1);
+
        /**
         * All errors, warnings, and notices.
         */
```