### PR TITLE
Fix incorrect constants

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -11,7 +11,7 @@ on.generating = false
 sha1.prefix = false
 
 [other]
-sigfiles.version = 1.6
+sigfiles.version = 1.7
 phpdoc.url = https://php.net/manual/en/
 license = ''
 

--- a/config.ini
+++ b/config.ini
@@ -22,4 +22,4 @@ method =
 functions = pdf
 function = __halt_compiler, array, delete, die, echo, empty, eval, exit, isset, list, main, print, unset
 constants =
-constant = ClassName::class, Swish*, SDO_DAS_ChangeSummary*, KTaglib_ID3v2_AttachedPictureFrame*, KTaglib_MPEG_Header*
+constant = ClassName::class, Swish*, SDO_DAS_ChangeSummary*, KTaglib_ID3v2_AttachedPictureFrame*, KTaglib_MPEG_Header*, 0x*


### PR DESCRIPTION
- https://www.php.net/manual/en/info.constants.php
- Don't add `0x*` of info.constants.html

```diff
--- a/output/info.php
+++ b/output/info.php
@@ -579,71 +579,6 @@
 	function zend_version(): string {}

 	/**
-	 * Microsoft Small Business Server was once installed on the system, but may have been upgraded to another version of Windows.
-	 */
-	define('0x00000001', null);
-
-	/**
-	 * Windows Server 2008 Enterprise, Windows Server 2003, Enterprise Edition, Windows 2000 Advanced Server, or Windows NT Server 4.0 Enterprise Edition is installed.
-	 */
-	define('0x00000002', null);
-
-	/**
-	 * Microsoft BackOffice components are installed.
-	 */
-	define('0x00000004', null);
-
-	/**
-	 * Terminal Services is installed. This value is always set. If this value is set but <code>0x00000100</code> is not set, then the system is running in application server mode.
-	 */
-	define('0x00000010', null);
-
-	/**
-	 * Microsoft Small Business Server is installed with the restrictive client license in force.
-	 */
-	define('0x00000020', null);
-
-	/**
-	 * Windows XP Embedded is installed.
-	 */
-	define('0x00000040', null);
-
-	/**
-	 * Windows Server 2008 Datacenter, Windows Server 2003, Datacenter Edition or Windows 2000 Datacenter Server is installed.
-	 */
-	define('0x00000080', null);
-
-	/**
-	 * Remote Desktop is supported, but only one interactive session is supported. This value is set unless the system is running in application server mode.
-	 */
-	define('0x00000100', null);
-
-	/**
-	 * Windows Vista Home Premium, Windows Vista Home Basic, or Windows XP Home Edition is installed.
-	 */
-	define('0x00000200', null);
-
-	/**
-	 * Windows Server 2003, Web Edition is installed.
-	 */
-	define('0x00000400', null);
-
-	/**
-	 * Windows Storage Server 2003 R2 or Windows Storage Server 2003 is installed.
-	 */
-	define('0x00002000', null);
-
-	/**
-	 * Windows Server 2003, Compute Cluster Edition is installed.
-	 */
-	define('0x00004000', null);
-
-	/**
-	 * Windows Home Server is installed.
-	 */
-	define('0x00008000', null);
-
-	/**
 	 * Enable <code>assert()</code> evaluation. <p><b>Warning</b></p><p>This feature has been <i>DEPRECATED</i> as of PHP 8.3.0. Relying on this feature is highly discouraged.</p>
 	 */
 	define('ASSERT_ACTIVE', 1);
```