### PR TITLE
Fix issues

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -11,7 +11,7 @@ on.generating = false
 sha1.prefix = false
 
 [other]
-sigfiles.version = 1.7
+sigfiles.version = 1.8
 phpdoc.url = https://php.net/manual/en/
 license = ''
 

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,5 +1,5 @@
 include.path=${php.global.include.path}
-php.version=PHP_82
+php.version=PHP_83
 source.encoding=UTF-8
 src.dir=.
 tags.asp=false

--- a/resources/licenses/phpsigfiles-notice.txt
+++ b/resources/licenses/phpsigfiles-notice.txt
@@ -1,6 +1,6 @@
 phpsigfiles is build from the PHP Manual by converting it to PHPdoc format.
 
-The PHP Manual is Copyright © 1997 - 2018 by the PHP Documentation Group.
+The PHP Manual is Copyright © 1997 - %CURRENT_YEAR% by the PHP Documentation Group.
 This material may be distributed only subject to the terms and conditions set
 forth in the Creative Commons Attribution 3.0 License or later. A copy of the
 Creative Commons Attribution 3.0 license is distributed with this distribution.

--- a/src/PhpClass.php
+++ b/src/PhpClass.php
@@ -59,6 +59,7 @@ class PhpClass extends PhpType {
                 $out .= implode(' ', $field->getModifiers());
                 $out .= ' ';
             }
+            $out .= $this->getFieldAndConstType($field);
             $out .= $field->getName();
             if ($field->getInitializer() !== null) {
                 $out .= ' ' . $field->getInitializer();

--- a/src/PhpClass.php
+++ b/src/PhpClass.php
@@ -8,10 +8,12 @@ class PhpClass extends PhpType {
     /** @var string[] */
     private $implements = [];
 
+    #[\Override]
     protected function createPhpMethod(string $file, PhpName $name): PhpMethod {
         return new PhpMethod($file, $name);
     }
 
+    #[\Override]
     protected function signatureInternal(bool $withPhpDoc, int $indent = 0): ?string {
         $out = $withPhpDoc ? $this->phpDoc->asType($indent) : '';
         $out .= Strings::indent($indent, '', false);
@@ -77,6 +79,7 @@ class PhpClass extends PhpType {
         return $out;
     }
 
+    #[\Override]
     protected function initInternal(): void {
         parent::initInternal();
         $this->implements = Html::queryValues($this->xpath(), './/div[@class="classsynopsisinfo"]//a[@class="interfacename"]', $this->typeInfo, true);

--- a/src/PhpConstant.php
+++ b/src/PhpConstant.php
@@ -12,6 +12,7 @@ class PhpConstant extends SigFileElement {
         $this->phpDoc = $phpDoc;
     }
 
+    #[\Override]
     protected function signatureInternal(bool $withPhpDoc, int $indent = 0): ?string {
         $out = '';
         $constantName = $this->name->getName();
@@ -45,6 +46,7 @@ class PhpConstant extends SigFileElement {
         return $out;
     }
 
+    #[\Override]
     protected function initInternal(): void {
         // noop
     }

--- a/src/PhpConstants.php
+++ b/src/PhpConstants.php
@@ -46,6 +46,7 @@ class PhpConstants extends PhpElements {
         return $name;
     }
 
+    #[\Override]
     protected function init(): void {
         $this->phpDoc = new PhpDoc($this->xpath());
         $this->phpDoc->parseConstants(self::getConstantsName($this->file), false, true);

--- a/src/PhpDoc.php
+++ b/src/PhpDoc.php
@@ -111,38 +111,40 @@ final class PhpDoc {
                 }
             }
         }
-        $nodes = Html::queryNodes($this->xpath, '//*[contains(@id, "' . strtolower($element) . '.constants")]//dl', null, true);
-        if ($nodes->length === 0) {
-            $nodes = Html::queryNodes($this->xpath, '//*[@id="' . strtolower($element) . '.constants.types"]//dl', null, true);
-        }
-        if ($nodes->length === 0) {
-            // e.g. class.mongocollection.html
-            $node = Html::queryFirstNode($this->xpath, '//dl/dt[contains(@id, ".constants")]', null, true);
-            if ($node !== null) {
-                $nodes = [$node->parentNode];
+        if (SourceDocFixer::detectDefinitionList($element)) {
+            $nodes = Html::queryNodes($this->xpath, '//*[contains(@id, "' . strtolower($element) . '.constants")]//dl', null, true);
+            if ($nodes->length === 0) {
+                $nodes = Html::queryNodes($this->xpath, '//*[@id="' . strtolower($element) . '.constants.types"]//dl', null, true);
             }
-        }
-        $names = [];
-        foreach ($nodes as $node) {
-            foreach ($node->childNodes as $childNode) {
-                switch ($childNode->nodeName) {
-                    case 'dt':
-                        $name = Php::sanitizeConstantName(trim($childNode->nodeValue), $sanitizeClassConstants);
-                        if (array_key_exists($name, $this->constants)) {
-                            Log::error("The constant key '$name' already exists");
-                        }
-                        $this->constants[$name][self::DESCRIPTION] = '';
-                        $names[] = $name;
-                        $typeNodes = Html::queryNodes($this->xpath, '//*[@class="type"]', $childNode, true);
-                        if (count($typeNodes) > 0) {
-                            $this->constants[$name][self::TYPE] = Php::sanitizeType($typeNodes->item(0)->nodeValue);
-                        }
-                        break;
-                    case 'dd':
-                        foreach ($names as $name) {
-                            $this->constants[$name][self::DESCRIPTION] = $this->nodeHtml($childNode);
-                        }
-                        $names = [];
+            if ($nodes->length === 0) {
+                // e.g. class.mongocollection.html
+                $node = Html::queryFirstNode($this->xpath, '//dl/dt[contains(@id, ".constants")]', null, true);
+                if ($node !== null) {
+                    $nodes = [$node->parentNode];
+                }
+            }
+            $names = [];
+            foreach ($nodes as $node) {
+                foreach ($node->childNodes as $childNode) {
+                    switch ($childNode->nodeName) {
+                        case 'dt':
+                            $name = Php::sanitizeConstantName(trim($childNode->nodeValue), $sanitizeClassConstants);
+                            if (array_key_exists($name, $this->constants)) {
+                                Log::error("The constant key '$name' already exists");
+                            }
+                            $this->constants[$name][self::DESCRIPTION] = '';
+                            $names[] = $name;
+                            $typeNodes = Html::queryNodes($this->xpath, '//*[@class="type"]', $childNode, true);
+                            if (count($typeNodes) > 0) {
+                                $this->constants[$name][self::TYPE] = Php::sanitizeType($typeNodes->item(0)->nodeValue);
+                            }
+                            break;
+                        case 'dd':
+                            foreach ($names as $name) {
+                                $this->constants[$name][self::DESCRIPTION] = $this->nodeHtml($childNode);
+                            }
+                            $names = [];
+                    }
                 }
             }
         }

--- a/src/PhpDoc.php
+++ b/src/PhpDoc.php
@@ -100,14 +100,23 @@ final class PhpDoc {
                 $columns = Html::queryNodes($this->xpath, './td[not(@class="empty")]', $row, false);
                 // constant name index of errorfunc.constants.html is 1
                 $nameIndex = SourceDocFixer::getConstantNameIndex($element);
-                $name = Php::sanitizeConstantName(trim($columns->item($nameIndex)->nodeValue), $sanitizeClassConstants);
-                if (array_key_exists($name, $this->constants)) {
-                    Log::error("The constant key '$name' already exists");
+                $constName = Php::sanitizeConstantName(trim($columns->item($nameIndex)->nodeValue), $sanitizeClassConstants);
+                $names = [];
+                if (Strings::contains($constName, '/')) {
+                    $constName = str_replace(' ', '', $constName);
+                    $names = explode('/', $constName);
+                } else {
+                    $names[] = $constName;
                 }
-                $this->constants[$name][self::DESCRIPTION] = $this->nodeHtml($columns->item($columns->length - 1));
-                $typeNodes = Html::queryNodes($this->xpath, '//*[@class="type"]', $row, true);
-                if (count($typeNodes) > 0) {
-                    $this->constants[$name][self::TYPE] = Php::sanitizeType($typeNodes->item(0)->nodeValue);
+                foreach ($names as $name) {
+                    if (array_key_exists($name, $this->constants)) {
+                        Log::error("The constant key '$name' already exists");
+                    }
+                    $this->constants[$name][self::DESCRIPTION] = $this->nodeHtml($columns->item($columns->length - 1));
+                    $typeNodes = Html::queryNodes($this->xpath, '//*[@class="type"]', $row, true);
+                    if (count($typeNodes) > 0) {
+                        $this->constants[$name][self::TYPE] = Php::sanitizeType($typeNodes->item(0)->nodeValue);
+                    }
                 }
             }
         }

--- a/src/PhpDoc.php
+++ b/src/PhpDoc.php
@@ -121,7 +121,7 @@ final class PhpDoc {
             }
         }
         if (SourceDocFixer::detectDefinitionList($element)) {
-            $nodes = Html::queryNodes($this->xpath, '//*[contains(@id, "' . strtolower($element) . '.constants")]//dl', null, true);
+            $nodes = Html::queryNodes($this->xpath, SourceDocFixer::getConstantDefinitionListExpression($element), null, true);
             if ($nodes->length === 0) {
                 $nodes = Html::queryNodes($this->xpath, '//*[@id="' . strtolower($element) . '.constants.types"]//dl', null, true);
             }

--- a/src/PhpFunction.php
+++ b/src/PhpFunction.php
@@ -6,11 +6,13 @@ use utils\Strings;
 
 class PhpFunction extends PhpMethod {
 
+    #[\Override]
     protected function signatureModifiers(): string {
         $this->modifiers = [];
         return parent::signatureModifiers();
     }
 
+    #[\Override]
     protected function initName(): void {
         $name = null;
         foreach (Html::queryNodes($this->xpath(), '//h1[@class="refname"]') as $h1) {
@@ -26,6 +28,7 @@ class PhpFunction extends PhpMethod {
         $this->name = PhpName::fromString($name);
     }
 
+    #[\Override]
     protected function isMySignature(string $signature): bool {
         return !Strings::contains($signature, '::');
     }

--- a/src/PhpFunctions.php
+++ b/src/PhpFunctions.php
@@ -22,6 +22,7 @@ class PhpFunctions extends PhpElements {
         return strtolower(str_replace($what, '', basename($ref)));
     }
 
+    #[\Override]
     protected function init(): void {
         $elements = $this->xpath()->query('//ul[@class="chunklist chunklist_reference"]//a[starts-with(@href, "function.")]');
         if (is_null($elements)) {

--- a/src/PhpInterface.php
+++ b/src/PhpInterface.php
@@ -5,13 +5,16 @@ use utils\Strings;
 
 class PhpInterface extends PhpType {
 
+    #[\Override]
     protected function createPhpMethod(string $file, PhpName $name): PhpMethod {
         return new class($file, $name) extends PhpMethod {
 
+            #[\Override]
             protected function signatureMethodBody(): string {
                 return ';';
             }
 
+            #[\Override]
             protected function signatureModifiers(): string {
                 $this->modifiers = array_diff($this->modifiers, ['abstract']);
                 return parent::signatureModifiers();
@@ -20,6 +23,7 @@ class PhpInterface extends PhpType {
         };
     }
 
+    #[\Override]
     protected function signatureInternal(bool $withPhpDoc, int $indent = 0): ?string {
         $out = $withPhpDoc ? $this->phpDoc->asType($indent) : '';
         $out .= Strings::indent($indent, '', false);

--- a/src/PhpInterface.php
+++ b/src/PhpInterface.php
@@ -51,6 +51,7 @@ class PhpInterface extends PhpType {
                 $out .= implode(' ', $field->getModifiers());
                 $out .= ' ';
             }
+            $out .= $this->getFieldAndConstType($field);
             $out .= $field->getName();
             if ($field->getInitializer() !== null) {
                 $out .= ' ' . $field->getInitializer();

--- a/src/PhpInternals.php
+++ b/src/PhpInternals.php
@@ -17,10 +17,12 @@ class PhpInternals {
                 $this->name = PhpName::fromString('stdClass');
             }
 
+            #[\Override]
             protected function initInternal(): void {
                 // noop
             }
 
+            #[\Override]
             protected function signatureInternal(bool $withPhpDoc, int $indent = 0): ?string {
                 $out = Strings::indent($indent, 'class stdClass {');
                 $out .= Strings::indent($indent, '}');

--- a/src/PhpMethod.php
+++ b/src/PhpMethod.php
@@ -27,6 +27,7 @@ class PhpMethod extends SigFileElement {
         '__clone',
     ];
 
+    #[\Override]
     protected function signatureInternal(bool $withPhpDoc, int $indent = 0): string {
         if ($this->alias) {
             return $this->signatureAlias($withPhpDoc, $indent);
@@ -35,6 +36,7 @@ class PhpMethod extends SigFileElement {
         }
     }
 
+    #[\Override]
     public function getName(): PhpName {
         $this->init();
         return $this->name;
@@ -48,6 +50,7 @@ class PhpMethod extends SigFileElement {
         return $this->type;
     }
 
+    #[\Override]
     protected function initInternal(): void {
         if ($this->name === null) {
             $this->initName();

--- a/src/PhpParameter.php
+++ b/src/PhpParameter.php
@@ -4,18 +4,22 @@ use utils\Php;
 
 class PhpParameter {
 
-    /** @var string */
-    private $type;
-    /** @var string */
-    private $name;
-    /** @var string */
-    private $initializer;
-    /** @var string */
-    private $phpDoc;
-    /** @var bool */
-    private $reference;
-    /** @var bool */
-    private $optional;
+    private ?string $attribute;
+    private string $type;
+    private string $name;
+    private ?string $initializer;
+    private ?string $phpDoc = null;
+    private bool $reference;
+    private bool $optional;
+
+    public function getAttribute(): ?string {
+        return $this->attribute;
+    }
+
+    public function setAttribute(?string $attribute): PhpParameter {
+        $this->attribute = $attribute;
+        return $this;
+    }
 
     public function getType(): ?string {
         return $this->type;

--- a/src/PhpType.php
+++ b/src/PhpType.php
@@ -295,4 +295,12 @@ abstract class PhpType extends SigFileElement {
         $this->methods[$name->getName()] = $this->createPhpMethod($file, $name);
     }
 
+    protected function getFieldAndConstType(PhpField $field): string {
+        $result = '';
+        $type = Php::sanitizeType($field->getType());
+        if ($type) {
+            $result .= $type . ' ';
+        }
+        return $result;
+    }
 }

--- a/src/PhpType.php
+++ b/src/PhpType.php
@@ -29,6 +29,7 @@ abstract class PhpType extends SigFileElement {
 
     protected abstract function createPhpMethod(string $file, PhpName $name): PhpMethod;
 
+    #[\Override]
     public function getName(): PhpName {
         return $this->name;
     }
@@ -44,6 +45,7 @@ abstract class PhpType extends SigFileElement {
         return $this->allConstantsPhpDoc;
     }
 
+    #[\Override]
     protected function initInternal(): void {
         $this->phpDoc = (new PhpDoc($this->xpath()))
             ->parseType($this->name->asHtmlIdent());

--- a/src/PhpType.php
+++ b/src/PhpType.php
@@ -218,6 +218,13 @@ abstract class PhpType extends SigFileElement {
         $constant = $className . "::" . $constName;
         $initializer = $classExists && defined($constant) ? constant($constant) : null;
         if ($initializer !== null) {
+            if ($initializer === true) {
+                $initializer = 'true';
+            } elseif ($initializer === false) {
+                $initializer = 'false';
+            } elseif (!is_numeric($initializer)) {
+                $initializer = "'$initializer'";
+            }
             if ($constType !== null) {
                 $initializer = Php::sanitizeInitializer($initializer, $constType);
             } else {

--- a/src/PhpTypes.php
+++ b/src/PhpTypes.php
@@ -27,6 +27,7 @@ class PhpTypes extends PhpElements {
         return strtolower(str_replace($what, '', basename($file)));
     }
 
+    #[\Override]
     protected function init(): void {
         $name = $this->initName();
         if (Config::get()->isBlacklistType($name->asString())) {

--- a/src/utils/Php.php
+++ b/src/utils/Php.php
@@ -111,7 +111,7 @@ final class Php {
         $partsCount = count($parts);
         if (!$phpDoc) {
             // resource?
-            if (in_array('resource', $parts)) {
+            if (in_array('resource', $parts) || in_array('?resource', $parts)) {
                 // resource => noop (phpdoc will help us)
                 return '';
             }
@@ -120,18 +120,7 @@ final class Php {
                 // void[|...] => void
                 return 'void';
             }
-            // false?
-            if (in_array('false', $parts)) {
-                if ($partsCount == 1) {
-                    // false => bool
-                    return 'bool';
-                }
-                if ($partsCount == 2
-                        && in_array('null', $parts)) {
-                    // null|false => ?bool
-                    return '?bool';
-                }
-            }
+            // PHP 8.2 allows null and false as stand-alone types
         }
         foreach ($parts as $part) {
             $prefix = self::isBuiltinType($part) ? '' : PhpName::DEFAULT_NAMESPACE;

--- a/src/utils/SourceDocFixer.php
+++ b/src/utils/SourceDocFixer.php
@@ -135,6 +135,19 @@ class SourceDocFixer {
         return $result;
     }
 
+    public static function getConstantDefinitionListExpression(string $name): string {
+        $result = '//*[contains(@id, "' . strtolower($name) . '.constants")]//dl';
+        switch ($name) {
+            case 'filter':
+                // filter.constants.html <dt><code class="literal">default</code></dt>
+                $result = '//*[contains(@id, "' . strtolower($element) . '.constants")]//dl[dt[@id]]';
+                break;
+            default:
+                break;
+        }
+        return $result;
+    }
+
     public static function detectDefinitionList(string $name): bool {
         // detect <dl></dl> or not
         switch ($name) {

--- a/src/utils/SourceDocFixer.php
+++ b/src/utils/SourceDocFixer.php
@@ -124,9 +124,25 @@ class SourceDocFixer {
             case 'debug-backtrace': // function.debug-backtrace.html
                 $result = '//dl/dd/table[@class="doctable table"]/tbody/tr';
                 break;
+            case 'info': // no break, info.constants.html
+            case 'curl': // curl.constants.html
+                // the first tr is <tr><th>Constants</th><th>Description</th></tr>, ignore it
+                $result = '//table[@class="doctable table"]/tr[1 < position()]';
+                break;
             default:
                 break;
         }
         return $result;
+    }
+
+    public static function detectDefinitionList(string $name): bool {
+        // detect <dl></dl> or not
+        switch ($name) {
+            case 'curl':
+                return false;
+            default:
+                break;
+        }
+        return true;
     }
 }

--- a/src/utils/SourceDocFixer.php
+++ b/src/utils/SourceDocFixer.php
@@ -17,6 +17,7 @@ class SourceDocFixer {
         switch ($htmlIdent) {
             case 'OCI-Collection':
             case 'OCI-Lob':
+            case 'RequestParseBodyException':
                 return $htmlIdent;
         }
         return null;

--- a/src/zip/SigfilesZipper.php
+++ b/src/zip/SigfilesZipper.php
@@ -106,7 +106,12 @@ class SigfilesZipper {
                     $contents = str_replace('%PHPSIGFILES_VERSION%', $sigfilesVersion, $contents);
                     $zip->addFromString($licenseFileDir . '/phpsigfiles' . Strings::appendPrefix($sigfilesVersion, '-') . '-license.txt', $contents);
                 } else if ($basename === 'phpsigfiles-notice.txt') {
-                    $zip->addFile($file, $licenseFileDir . '/phpsigfiles' . Strings::appendPrefix($sigfilesVersion, '-') . '-notice.txt');
+                    $contents = file_get_contents($file);
+                    if ($contents === false) {
+                        Log::error('Cannot get notice file contents: ' . $file, true);
+                    }
+                    $contents = str_replace('%CURRENT_YEAR%', date('Y'), $contents);
+                    $zip->addFromString($licenseFileDir . '/phpsigfiles' . Strings::appendPrefix($sigfilesVersion, '-') . '-notice.txt', $contents);
                 } else {
                     $zip->addFile($file, $licenseFileDir . '/' . basename($file));
                 }


### PR DESCRIPTION
Fixed issues for a current documentation:
Size: 10554Kb
Date: 6 Jan 2025

- Fix an incorrect synopsis id of RequestParseBodyException 
  - Do not change the name(RequestParseBodyException) to lowercase
- Fix constants for curl and info
  - Get constants from a table (not a definition list)
  - curl.constants.html
  - info.constants.html
- Fix constant names separated with / 
  - See: dom.constants.html
  - e.g. `DOMSTRING_SIZE_ERR / Dom\STRING_SIZE_ERR`
- Fix the filter constants
  - Fix the memcached constants 
```diff
diff --git a/output/memcached.php b/output/memcached.php
index 01175782..2a3ad967 100644
--- a/output/memcached.php
+++ b/output/memcached.php
@@ -325,43 +325,43 @@ namespace {
                 * @var boolean Indicates whether igbinary serializer support is available. <p>Type: <code>bool</code>.</p>
                 * @link https://php.net/manual/en/memcached.constants.php
                 */
-               const HAVE_IGBINARY = 1;
+               const HAVE_IGBINARY = true;

                /**
                 * @var boolean Indicates whether JSON serializer support is available. <p>Type: <code>bool</code>.</p>
                 * @link https://php.net/manual/en/memcached.constants.php
                 */
-               const HAVE_JSON = 1;
+               const HAVE_JSON = true;

                /**
                 * @var boolean Indicates whether MessagePack serializer support is available. <p>Type: <code>bool</code>.</p> <p>Available as of Memcached 3.0.0.</p>
                 * @link https://php.net/manual/en/memcached.constants.php
                 */
-               const HAVE_MSGPACK = 1;
+               const HAVE_MSGPACK = true;

                /**
                 * @var boolean Indicates whether ZSTD compression support is available. <p>Type: <code>bool</code>.</p> <p>Available as of Memcached 3.3.0.</p>
                 * @link https://php.net/manual/en/memcached.constants.php
                 */
-               const HAVE_ZSTD = ;
+               const HAVE_ZSTD = false;

                /**
                 * @var boolean Indicates whether data encryption using <code>Memcached::setEncodingKey()</code> is supported.  <p>Type: <code>bool</code>.</p> <p>Available as of Memcached 3.1.0.</p>
                 * @link https://php.net/manual/en/memcached.constants.php
                 */
-               const HAVE_ENCODING = 1;
+               const HAVE_ENCODING = true;

                /**
                 * @var boolean <p>Type: <code>bool</code>.</p> <p>Available as of Memcached 3.0.0.</p>
                 * @link https://php.net/manual/en/memcached.constants.php
                 */
-               const HAVE_SESSION = 1;
+               const HAVE_SESSION = true;

                /**
                 * @var boolean <p>Type: <code>bool</code>.</p> <p>Available as of Memcached 3.0.0.</p>
                 * @link https://php.net/manual/en/memcached.constants.php
                 */
-               const HAVE_SASL = 1;
+               const HAVE_SASL = true;

                /**
                 * @var integer <p>A flag for <code>Memcached::get()</code>, <code>Memcached::getMulti()</code> and <code>Memcached::getMultiByKey()</code> to ensure that the CAS token values are returned as well.</p> <p>Available as of Memcached 3.0.0.</p>
```
- Add attributes for parameters 
```diff
diff --git a/output/strings.php b/output/strings.php
index 3c859dc3..2cde88e8 100644
--- a/output/strings.php
+++ b/output/strings.php
@@ -139,7 +139,7 @@ namespace {
         * @see hash_equals(), password_hash()
         * @SInCE PHP 4, PHP 5, PHP 7, PHP 8
         */
-       function crypt(string $string = NULL, string $salt): string {}
+       function crypt(#[\SensitiveParameter] string $string, string $salt): string {}

        /**
         * Split a string by a string
```
- Add field and const types 

- Update version to PHP 8.3
```diff
diff --git a/output/argumentcounterror.php b/output/argumentcounterror.php
index 4327afb8..bf378af3 100644
--- a/output/argumentcounterror.php
+++ b/output/argumentcounterror.php
@@ -14,43 +14,43 @@ namespace {
                 * @var string <p>The error message</p>
                 * @link https://php.net/manual/en/class.error.php#error.props.message
                 */
-               protected $message = "";
+               protected string $message = "";

                /**
                 * @var string <p>The string representation of the stack trace</p>
                 * @link https://php.net/manual/en/class.error.php#error.props.string
                 */
-               private $string = "";
+               private string $string = "";

                /**
                 * @var int <p>The error code</p>
                 * @link https://php.net/manual/en/class.error.php#error.props.code
                 */
-               protected $code;
+               protected int $code;

                /**
                 * @var string <p>The filename where the error happened</p>
                 * @link https://php.net/manual/en/class.error.php#error.props.file
                 */
-               protected $file = "";
+               protected string $file = "";

                /**
                 * @var int <p>The line where the error happened</p>
                 * @link https://php.net/manual/en/class.error.php#error.props.line
                 */
-               protected $line;
+               protected int $line;

                /**
                 * @var array <p>The stack trace as an array</p>
                 * @link https://php.net/manual/en/class.error.php#error.props.trace
                 */
-               private $trace = [];
+               private array $trace = [];

                /**
                 * @var ?Throwable <p>The previously thrown exception</p>
                 * @link https://php.net/manual/en/class.error.php#error.props.previous
                 */
-               private $previous = null;
+               private ?\Throwable $previous = null;

                /**
                 * Clone the error
```
- Improve the notice file 
  - Add a current year (replace `%CURRENT_YEAR%` to a current year)
- Add #[\Override]
- Update sigfiles version number to 1.8